### PR TITLE
Fix datatype for Id.

### DIFF
--- a/ChromaDB.Client/Common/Mappers/CollectionEntryMapper.cs
+++ b/ChromaDB.Client/Common/Mappers/CollectionEntryMapper.cs
@@ -14,7 +14,7 @@ namespace ChromaDB.Client.Common.Mappers
 		public static List<CollectionEntry> Map(this CollectionEntriesResponse response)
 		{
 			List<CollectionEntry> entries = new();
-			List<Guid> ids = response.Ids;
+			List<string> ids = response.Ids;
 			try
 			{
 				for (int i = 0; i < ids.Count; i++)

--- a/ChromaDB.Client/Models/CollectionEntry.cs
+++ b/ChromaDB.Client/Models/CollectionEntry.cs
@@ -8,7 +8,7 @@ namespace ChromaDB.Client.Models
 {
 	public class CollectionEntry
 	{
-		public Guid Id { get; set; }
+		public string Id { get; set; }
 		public List<float>? Embeddings { get; set; }
 		public Dictionary<string, object>? Metadata { get; set; }
 		public List<string?>? Uris { get; set; }

--- a/ChromaDB.Client/Models/Requests/CollectionGetRequest.cs
+++ b/ChromaDB.Client/Models/Requests/CollectionGetRequest.cs
@@ -10,7 +10,7 @@ namespace ChromaDB.Client.Models.Requests
 	public class CollectionGetRequest
 	{
 		[JsonPropertyName("ids")]
-		public required List<Guid> Ids { get; init; }
+		public required List<string> Ids { get; init; }
 
 		[JsonPropertyName("where")]
 		public IDictionary<string, object>? Where { get; init; }

--- a/ChromaDB.Client/Models/Requests/CollectionQueryRequest.cs
+++ b/ChromaDB.Client/Models/Requests/CollectionQueryRequest.cs
@@ -10,7 +10,7 @@ namespace ChromaDB.Client.Models.Requests
 	public class CollectionQueryRequest
 	{
 		[JsonPropertyName("ids")]
-		public required List<Guid> Ids { get; init; }
+		public required List<string> Ids { get; init; }
 
 		[JsonPropertyName("where")]
 		public IDictionary<string, object>? Where { get; init; }

--- a/ChromaDB.Client/Models/Responses/CollectionEntriesQueryResponse.cs
+++ b/ChromaDB.Client/Models/Responses/CollectionEntriesQueryResponse.cs
@@ -5,7 +5,7 @@ namespace ChromaDB.Client.Models.Responses
     public class CollectionEntriesQueryResponse
 	{
 		[JsonPropertyName("ids")]
-		public required List<List<Guid>> Ids { get; set; }
+		public required List<List<string>> Ids { get; set; }
 
 		[JsonPropertyName("embeddings")]
 		public required List<List<List<float>>> Embeddings { get; set; }

--- a/ChromaDB.Client/Models/Responses/CollectionEntriesResponse.cs
+++ b/ChromaDB.Client/Models/Responses/CollectionEntriesResponse.cs
@@ -10,7 +10,7 @@ namespace ChromaDB.Client.Models.Responses
     public class CollectionEntriesResponse
     {
         [JsonPropertyName("ids")]
-        public required List<Guid> Ids { get; set; }
+        public required List<string> Ids { get; set; }
 
         [JsonPropertyName("embeddings")]
         public required List<List<float>> Embeddings { get; set; }

--- a/Samples/ChromaDB.Client.Console/Program.cs
+++ b/Samples/ChromaDB.Client.Console/Program.cs
@@ -29,7 +29,7 @@ namespace ChromaDB.Client.Console
 
 				BaseResponse<List<CollectionEntry>> getResponse = await string5Client.Get(new CollectionGetRequest()
 				{
-					Ids = new List<Guid>() { Guid.Parse("340a36ad-c38a-406c-be38-250174aee5a4") },
+					Ids = new List<string>() { "340a36ad-c38a-406c-be38-250174aee5a4" },
 					Include = new List<string>() { "metadatas", "documents", "embeddings" }
 				});
 
@@ -37,7 +37,7 @@ namespace ChromaDB.Client.Console
 
 				BaseResponse<CollectionEntriesQueryResponse> queryResponse = await string5Client.Query(new CollectionQueryRequest()
 				{
-					Ids = new List<Guid>() { Guid.Parse("340a36ad-c38a-406c-be38-250174aee5a4") },
+					Ids = new List<string>() { "340a36ad-c38a-406c-be38-250174aee5a4" },
 					Include = new List<string>() { "metadatas", "documents", "embeddings" },
 					QueryEmbeddings = new List<List<float>>()
 					{


### PR DESCRIPTION
Chroma does not require _id_ to be `Guid` and hence reading from collection where _ids_ are non-`Guid`s would fail.